### PR TITLE
Support for RSpec 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ gemfile:
   - Gemfile
   - ci/gemfiles/rspec2_14_rails4_0.gemfile
   - ci/gemfiles/rspec2_14_rails3_2.gemfile
+  - ci/gemfiles/rspec3_0_rails4_0.gemfile
+  - ci/gemfiles/rspec3_0_rails3_2.gemfile
 before_script:
   - ci/script/create_db.sh
   - bundle exec rake db:test:reset --trace

--- a/ci/gemfiles/rspec3_0_rails3_2.gemfile
+++ b/ci/gemfiles/rspec3_0_rails3_2.gemfile
@@ -1,0 +1,22 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in foreigner-matcher.gemspec
+gemspec :path => '../../'
+
+group :test do
+  gem "rake"
+  gem "rspec",        "~> 3.0.0"
+  gem "mocha",        "~> 1.1.0"
+  gem "activerecord", "~> 3.2.0"
+  gem "railties",     "~> 3.2.0"
+
+  platforms :ruby do
+    gem "mysql2",     "~> 0.3.0"
+    gem "pg",         "~> 0.17.0"
+  end
+
+  platforms :jruby do
+    gem "activerecord-jdbcmysql-adapter"
+    gem "activerecord-jdbcpostgresql-adapter"
+  end
+end

--- a/ci/gemfiles/rspec3_0_rails4_0.gemfile
+++ b/ci/gemfiles/rspec3_0_rails4_0.gemfile
@@ -1,0 +1,30 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in foreigner-matcher.gemspec
+gemspec :path => '../../'
+
+group :development do
+  gem "yard"
+end
+
+group :development, :test do
+  gem "pry"
+end
+
+group :test do
+  gem "rake"
+  gem "rspec",        "~> 3.0.0"
+  gem "mocha",        "~> 1.1.0"
+  gem "activerecord", "~> 4.0.0"
+  gem "railties",     "~> 4.0.0"
+
+  platforms :ruby do
+    gem "mysql2",     "~> 0.3.0"
+    gem "pg",         "~> 0.17.0"
+  end
+
+  platforms :jruby do
+    gem "activerecord-jdbcmysql-adapter"
+    gem "activerecord-jdbcpostgresql-adapter"
+  end
+end

--- a/lib/foreigner-matcher.rb
+++ b/lib/foreigner-matcher.rb
@@ -17,11 +17,11 @@ module ForeignerMatcher # :nodoc:
       desc
     end
 
-    def failure_message_for_should
+    def failure_message
       "expected #{display_child_foreign_keys} to include #{foreign_key_definition}"
     end
 
-    def failure_message_for_should_not
+    def failure_message_when_negated
       "expected #{display_child_foreign_keys} to exclude #{foreign_key_definition}"
     end
 

--- a/spec/foreigner_matcher_spec.rb
+++ b/spec/foreigner_matcher_spec.rb
@@ -4,7 +4,7 @@ describe ForeignerMatcher::HaveForeignKeyFor do
   describe 'methods' do
     subject { ForeignerMatcher::HaveForeignKeyFor.new(mock) }
 
-    [ :matches?, :description, :failure_message_for_should, :failure_message_for_should_not ].each do |klass_method|
+    [ :matches?, :description, :failure_message, :failure_message_when_negated ].each do |klass_method|
       it "should respond to #{klass_method}" do
         subject.should respond_to(klass_method)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,13 @@ end
 
 # Configure rspec options
 RSpec.configure do |config|
+
+  # Explicitly allow the old `object.should` syntax. We disallow the new
+  # `expect(object)` syntax for now to enforce consistency.
+  config.expect_with :rspec do |c|
+    c.syntax = :should
+  end
+
   config.mock_framework = :mocha
 
   config.include(ConnectionHelpers)

--- a/spec/test_models/comment_spec.rb
+++ b/spec/test_models/comment_spec.rb
@@ -7,18 +7,18 @@ describe Comment do
       matcher.description.should == 'have a foreign key for users with {:dependent=>:delete}'
     end
 
-    it 'should set failure_message_for_should message' do
+    it 'should set failure_message message' do
       stub_fkd_to_s_with('expected fk')
       matcher = have_foreign_key_for(:comments)
       matcher.matches?(subject)
-      matcher.failure_message_for_should.should == "expected #{foreign_keys_for('comments')} to include expected fk"
+      matcher.failure_message.should == "expected #{foreign_keys_for('comments')} to include expected fk"
     end
 
-    it 'should set failure_message_for_should_not message' do
+    it 'should set failure_message_when_negated message' do
       stub_fkd_to_s_with('unexpected fk')
       matcher = have_foreign_key_for(:users, :dependent => :delete)
       matcher.matches?(subject)
-      matcher.failure_message_for_should_not.should == "expected #{foreign_keys_for('comments')} to exclude unexpected fk"
+      matcher.failure_message_when_negated.should == "expected #{foreign_keys_for('comments')} to exclude unexpected fk"
     end
   end
 

--- a/spec/test_models/default_option_spec.rb
+++ b/spec/test_models/default_option_spec.rb
@@ -7,18 +7,18 @@ describe DefaultOption do
       matcher.description.should == 'have a foreign key for users'
     end
 
-    it 'should set failure_message_for_should message' do
+    it 'should set failure_message message' do
       stub_fkd_to_s_with('expected fk')
       matcher = have_foreign_key_for(:default_options)
       matcher.matches?(subject)
-      matcher.failure_message_for_should.should == "expected #{foreign_keys_for('default_options')} to include expected fk"
+      matcher.failure_message.should == "expected #{foreign_keys_for('default_options')} to include expected fk"
     end
 
-    it 'should set failure_message_for_should_not message' do
+    it 'should set failure_message_when_negated message' do
       stub_fkd_to_s_with('unexpected fk')
       matcher = have_foreign_key_for(:users)
       matcher.matches?(subject)
-      matcher.failure_message_for_should_not.should == "expected #{foreign_keys_for('default_options')} to exclude unexpected fk"
+      matcher.failure_message_when_negated.should == "expected #{foreign_keys_for('default_options')} to exclude unexpected fk"
     end
   end
 

--- a/spec/test_models/search_spec.rb
+++ b/spec/test_models/search_spec.rb
@@ -7,18 +7,18 @@ describe Search do
       matcher.description.should == 'have a foreign key for users with {:dependent=>:delete, :name=>"user_search_special_fk"}'
     end
 
-    it 'should set failure_message_for_should message' do
+    it 'should set failure_message message' do
       stub_fkd_to_s_with('expected fk')
       matcher = have_foreign_key_for(:searches)
       matcher.matches?(subject)
-      matcher.failure_message_for_should.should == "expected #{foreign_keys_for('searches')} to include expected fk"
+      matcher.failure_message.should == "expected #{foreign_keys_for('searches')} to include expected fk"
     end
 
-    it 'should set failure_message_for_should_not message' do
+    it 'should set failure_message_when_negated message' do
       stub_fkd_to_s_with('unexpected fk')
       matcher = have_foreign_key_for(:users, :name => 'user_search_special_fk', :dependent => :delete)
       matcher.matches?(subject)
-      matcher.failure_message_for_should_not.should == "expected #{foreign_keys_for('searches')} to exclude unexpected fk"
+      matcher.failure_message_when_negated.should == "expected #{foreign_keys_for('searches')} to exclude unexpected fk"
     end
   end
 

--- a/spec/test_models/special_user_record_spec.rb
+++ b/spec/test_models/special_user_record_spec.rb
@@ -7,18 +7,18 @@ describe SpecialUserRecord do
       matcher.description.should == 'have a foreign key for users with {:column=>"special_user_id", :dependent=>:delete, :name=>"special_user_records_special_user_id_fk"}'
     end
 
-    it 'should set failure_message_for_should message' do
+    it 'should set failure_message message' do
       stub_fkd_to_s_with('expected fk')
       matcher = have_foreign_key_for(:special_user_records)
       matcher.matches?(subject)
-      matcher.failure_message_for_should.should == "expected #{foreign_keys_for('special_user_records')} to include expected fk"
+      matcher.failure_message.should == "expected #{foreign_keys_for('special_user_records')} to include expected fk"
     end
 
-    it 'should set failure_message_for_should_not message' do
+    it 'should set failure_message_when_negated message' do
       stub_fkd_to_s_with('unexpected fk')
       matcher = have_foreign_key_for(:users, :column => 'special_user_id', :name => 'special_user_records_special_user_id_fk', :dependent => :delete)
       matcher.matches?(subject)
-      matcher.failure_message_for_should_not.should == "expected #{foreign_keys_for('special_user_records')} to exclude unexpected fk"
+      matcher.failure_message_when_negated.should == "expected #{foreign_keys_for('special_user_records')} to exclude unexpected fk"
     end
   end
 

--- a/spec/test_models/table_without_foreign_key_spec.rb
+++ b/spec/test_models/table_without_foreign_key_spec.rb
@@ -8,16 +8,16 @@ describe TableWithoutForeignKey do
       matcher.description.should == 'have a foreign key for users'
     end
 
-    it 'should set failure_message_for_should message' do
+    it 'should set failure_message message' do
       stub_fkd_to_s_with('expected fk')
       matcher.matches?(subject)
-      matcher.failure_message_for_should.should == "expected foreign keys to include expected fk"
+      matcher.failure_message.should == "expected foreign keys to include expected fk"
     end
 
-    it 'should set failure_message_for_should_not message' do
+    it 'should set failure_message_when_negated message' do
       stub_fkd_to_s_with('unexpected fk')
       matcher.matches?(subject)
-      matcher.failure_message_for_should_not.should == "expected foreign keys to exclude unexpected fk"
+      matcher.failure_message_when_negated.should == "expected foreign keys to exclude unexpected fk"
     end
   end
 

--- a/spec/test_models/user_login_spec.rb
+++ b/spec/test_models/user_login_spec.rb
@@ -7,18 +7,18 @@ describe UserLogin do
       matcher.description.should == 'have a foreign key for users with {:dependent=>:nullify}'
     end
 
-    it 'should set failure_message_for_should message' do
+    it 'should set failure_message message' do
       stub_fkd_to_s_with('expected fk')
       matcher = have_foreign_key_for(:user_logins)
       matcher.matches?(subject)
-      matcher.failure_message_for_should.should == "expected #{foreign_keys_for('user_logins')} to include expected fk"
+      matcher.failure_message.should == "expected #{foreign_keys_for('user_logins')} to include expected fk"
     end
 
-    it 'should set failure_message_for_should_not message' do
+    it 'should set failure_message_when_negated message' do
       stub_fkd_to_s_with('unexpected fk')
       matcher = have_foreign_key_for(:users, :dependent => :nullify)
       matcher.matches?(subject)
-      matcher.failure_message_for_should_not.should == "expected #{foreign_keys_for('user_logins')} to exclude unexpected fk"
+      matcher.failure_message_when_negated.should == "expected #{foreign_keys_for('user_logins')} to exclude unexpected fk"
     end
   end
 

--- a/spec/test_models/user_type_spec.rb
+++ b/spec/test_models/user_type_spec.rb
@@ -7,18 +7,18 @@ describe UserType do
       matcher.description.should == 'have a foreign key for users'
     end
 
-    it 'should set failure_message_for_should message' do
+    it 'should set failure_message message' do
       stub_fkd_to_s_with('expected fk')
       matcher = have_foreign_key_for(:user_types)
       matcher.matches?(subject)
-      matcher.failure_message_for_should.should == "expected #{foreign_keys_for('user_types')} to include expected fk"
+      matcher.failure_message.should == "expected #{foreign_keys_for('user_types')} to include expected fk"
     end
 
-    it 'should set failure_message_for_should_not message' do
+    it 'should set failure_message_when_negated message' do
       stub_fkd_to_s_with('unexpected fk')
       matcher = have_foreign_key_for(:users)
       matcher.matches?(subject)
-      matcher.failure_message_for_should_not.should == "expected #{foreign_keys_for('user_types')} to exclude unexpected fk"
+      matcher.failure_message_when_negated.should == "expected #{foreign_keys_for('user_types')} to exclude unexpected fk"
     end
   end
 


### PR DESCRIPTION
This fixes deprecation warnings that appear in this gem's specs and in your application's specs if you run your tests using RSpec 3.0. Examples:

```
--------------------------------------------------------------------------------
ForeignerMatcher::HaveForeignKeyFor implements a legacy RSpec matcher
protocol. For the current protocol you should expose the failure messages
via the `failure_message` and `failure_message_when_negated` methods.
(Used from foreigner-matcher/spec/test_models/comment_spec.rb:26:in 
`block (3 levels) in <top (required)>')
--------------------------------------------------------------------------------
```

```
Using `should` from rspec-expectations' old `:should` syntax without explicitly 
enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly 
enable `:should` instead. 
Called from foreigner-matcher/spec/foreigner_matcher_spec.rb:9:in 
`block (4 levels) in <top (required)>'.
```

I did not update the `Gemfile` to explicitly bump the version of RSpec up to 3.0. But I did try this code against both 2.x and 3.x to verify that it was compatible with both. You could also consider expanding the version requirement in the `Gemfile` to this:

``` diff
diff --git a/Gemfile b/Gemfile
index bfd2723..5d89827 100644
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end

 group :test do
   gem "rake"
-  gem "rspec",        "~> 2.14.0"
+  gem "rspec",        ">= 2.14.0"
   gem "mocha",        "~> 1.1.0"
   gem "activerecord", "~> 4.1.0"
   gem "railties",     "~> 4.1.0"
```
